### PR TITLE
[FIX] account_financial_risk: allow to define non stored computed fields in all partners

### DIFF
--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -119,7 +119,7 @@ class ResPartner(models.Model):
 
     def _compute_risk_allow_edit(self):
         is_editable = self.env.user.has_group("account.group_account_manager")
-        for partner in self.filtered("customer_rank"):
+        for partner in self:
             partner.risk_allow_edit = is_editable
 
     @api.depends(
@@ -237,7 +237,7 @@ class ResPartner(models.Model):
     @api.depends(lambda x: x._get_depends_compute_risk_exception())
     def _compute_risk_exception(self):
         risk_field_list = self._risk_field_list()
-        for partner in self.filtered("customer_rank"):
+        for partner in self:
             amount = 0.0
             risk_exception = False
             for risk_field in risk_field_list:


### PR DESCRIPTION
This PR solves the issue when you try to open a partner form view when is not customer it raises res.partner(1234),risk_exception

This is based on the migration instruction from [Migration to version 13.0](https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-13.0#tasks-to-do-in-the-migration)

- Computed stored fields will keep their previous value if not assigned during the compute method, so don't rely on any expected default value.
